### PR TITLE
feat(compat): add explicit Codex skills support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Development guide for coding agents working in the loadout repository.
 
 ## Project Overview
 
-**loadout** is a skill lifecycle management system for AI agents (OpenCode and Claude Code). It manages SKILL.md files by symlinking them from user-controlled directories into tool discovery paths.
+**loadout** is a skill lifecycle management system for AI agents (OpenCode, Claude Code, and Codex). It manages SKILL.md files by symlinking them from user-controlled directories into tool discovery paths.
 
 - **Language**: Rust (Edition 2021), currently in Phase 2 development (v0.2.0-dev)
 - **Phase 1**: Bash scripts implementation (complete, in `scripts/`)
@@ -285,12 +285,12 @@ resolve_skill
 - **Schema**: `schema/skill-frontmatter.json`
 
 ### Discovery Paths (Target Directories)
-- `~/.claude/skills/` (global, both tools)
+- `~/.claude/skills/` (global, Claude Code)
 - `~/.config/opencode/skills/` (global, OpenCode)
-- `~/.agents/skills/` (global, both tools)
-- `.claude/skills/` (project-local, both tools)
+- `~/.agents/skills/` (global, Codex + compatible tools)
+- `.claude/skills/` (project-local, Claude Code)
 - `.opencode/skills/` (project-local, OpenCode)
-- `.agents/skills/` (project-local, both tools)
+- `.agents/skills/` (project-local, Codex + compatible tools)
 
 ## SKILL.md Format
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+- Explicitly documented Codex support via `~/.agents/skills` and `.agents/skills` discovery paths
+- Clarified compatibility wording across README, design docs, example config, and agent guidance
+- Updated frontmatter schema/docs to note permissive passthrough for tool-specific keys (including Codex)
+
+### Added
+- Regression tests for project `.agents/skills` handling in `install`, `clean`, and `check` commands
+
 ## [0.3.5] — 2026-02-12
 
 Phases 2, 3, and 3.5: Rust CLI, analysis commands, and metadata.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -78,16 +78,16 @@ personal directory. The install script will use yours.
 
 ## Compatibility
 
-Both OpenCode and Claude Code discover skills from:
+OpenCode, Claude Code, and Codex discover skills from:
 
 | Path | Scope | Tool |
 |------|-------|------|
-| `.claude/skills/<name>/SKILL.md` | Project | Both |
-| `~/.claude/skills/<name>/SKILL.md` | Global | Both |
+| `.claude/skills/<name>/SKILL.md` | Project | Claude Code |
+| `~/.claude/skills/<name>/SKILL.md` | Global | Claude Code |
 | `.opencode/skills/<name>/SKILL.md` | Project | OpenCode |
 | `~/.config/opencode/skills/<name>/SKILL.md` | Global | OpenCode |
-| `.agents/skills/<name>/SKILL.md` | Project | Both |
-| `~/.agents/skills/<name>/SKILL.md` | Global | Both |
+| `.agents/skills/<name>/SKILL.md` | Project | Codex and compatible tools |
+| `~/.agents/skills/<name>/SKILL.md` | Global | Codex and compatible tools |
 
 The install script symlinks into the appropriate target paths.
 Claude Code extensions in frontmatter (`disable-model-invocation`,

--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 Skill management for AI development tools.
 
 Loadout is the tool that links your skills into the discovery paths
-that [OpenCode](https://opencode.ai) and
-[Claude Code](https://docs.anthropic.com/en/docs/claude-code) scan.
+that [OpenCode](https://opencode.ai),
+[Claude Code](https://docs.anthropic.com/en/docs/claude-code), and
+[Codex](https://developers.openai.com/codex/skills) scan.
 Your skills live wherever you want. Loadout wires them up.
 
 ## How it works
@@ -19,7 +20,7 @@ Your skills live wherever you want. Loadout wires them up.
 
 ~/.claude/skills/             → Claude Code discovers them
 ~/.config/opencode/skills/    → OpenCode discovers them
-~/.agents/skills/             → Any compatible tool
+~/.agents/skills/             → Codex and other compatible tools discover them
 ```
 
 The repo contains the scripts and schema. Your personal config and
@@ -143,20 +144,22 @@ Use `loadout --help` or `loadout <command> --help` for detailed usage.
 
 ## Compatibility
 
-The install script symlinks into all paths that OpenCode and Claude
-Code scan:
+The install command symlinks into all paths that OpenCode, Claude Code,
+and Codex scan:
 
 | Path | Scope | Tool |
 |------|-------|------|
-| `~/.claude/skills/` | Global | Both |
+| `~/.claude/skills/` | Global | Claude Code |
 | `~/.config/opencode/skills/` | Global | OpenCode |
-| `~/.agents/skills/` | Global | Both |
-| `.claude/skills/` | Project | Both |
+| `~/.agents/skills/` | Global | Codex and compatible tools |
+| `.claude/skills/` | Project | Claude Code |
 | `.opencode/skills/` | Project | OpenCode |
-| `.agents/skills/` | Project | Both |
+| `.agents/skills/` | Project | Codex and compatible tools |
 
 Claude Code frontmatter extensions (`disable-model-invocation`,
 `context`, `allowed-tools`) are silently ignored by OpenCode.
+Codex-specific frontmatter keys are also allowed and passed through by
+loadout.
 
 ## SKILL.md format
 

--- a/loadout.example.toml
+++ b/loadout.example.toml
@@ -22,7 +22,7 @@ skills = [
 targets = [
   "~/.claude/skills",
   "~/.config/opencode/skills",
-  "~/.agents/skills",
+  "~/.agents/skills",           # Codex + compatible tools
 ]
 
 # List skill names to enable globally.

--- a/schema/skill-frontmatter.json
+++ b/schema/skill-frontmatter.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/pentaxis93/loadout/schema/skill-frontmatter.json",
   "title": "SKILL.md Frontmatter",
-  "description": "Validates YAML frontmatter in SKILL.md files. Union of OpenCode and Claude Code fields.",
+  "description": "Validates YAML frontmatter in SKILL.md files. Union of OpenCode and Claude Code fields, with permissive passthrough for Codex and future tool keys.",
   "type": "object",
   "required": ["name", "description"],
   "properties": {

--- a/src/commands/check.rs
+++ b/src/commands/check.rs
@@ -605,6 +605,9 @@ pub fn exit_code(findings: &[Finding]) -> i32 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
+    use std::os::unix::fs::symlink;
+    use tempfile::TempDir;
 
     // Helper to create a test skill
     fn test_skill(name: &str, description: &str) -> Skill {
@@ -630,6 +633,27 @@ mod tests {
                 tags: None,
                 pipeline: None,
             },
+        }
+    }
+
+    fn test_config_with_project(temp: &TempDir) -> Config {
+        let mut projects = HashMap::new();
+        projects.insert(
+            temp.path().join("project"),
+            crate::config::Project {
+                skills: vec![],
+                inherit: true,
+            },
+        );
+
+        Config {
+            sources: crate::config::Sources { skills: vec![] },
+            global: crate::config::Global {
+                targets: vec![temp.path().join("global-target")],
+                skills: vec![],
+            },
+            projects,
+            check: Default::default(),
         }
     }
 
@@ -686,6 +710,55 @@ mod tests {
         assert_eq!(findings[0].severity, Severity::Warning);
         assert!(findings[0].message.contains("skill-b"));
         assert!(findings[0].fix.contains("loadout.toml"));
+    }
+
+    #[test]
+    fn should_detect_broken_symlink_in_agents_project_directory() {
+        // Given
+        let temp = TempDir::new().unwrap();
+        let config = test_config_with_project(&temp);
+        let agents_target = temp.path().join("project/.agents/skills");
+        fs::create_dir_all(&agents_target).unwrap();
+        symlink(
+            temp.path().join("missing-target"),
+            agents_target.join("broken-skill"),
+        )
+        .unwrap();
+
+        // When
+        let findings = check_broken_symlinks(&config).unwrap();
+
+        // Then
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].severity, Severity::Error);
+        assert!(findings[0]
+            .path
+            .as_ref()
+            .unwrap()
+            .ends_with("project/.agents/skills/broken-skill"));
+    }
+
+    #[test]
+    fn should_detect_unmanaged_directory_in_agents_project_directory() {
+        // Given
+        let temp = TempDir::new().unwrap();
+        let config = test_config_with_project(&temp);
+        let agents_target = temp.path().join("project/.agents/skills");
+        let unmanaged_dir = agents_target.join("manual-skill");
+        fs::create_dir_all(&unmanaged_dir).unwrap();
+        fs::write(unmanaged_dir.join("SKILL.md"), "manual").unwrap();
+
+        // When
+        let findings = check_unmanaged_conflicts(&config).unwrap();
+
+        // Then
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].severity, Severity::Warning);
+        assert!(findings[0]
+            .path
+            .as_ref()
+            .unwrap()
+            .ends_with("project/.agents/skills/manual-skill"));
     }
 
     #[test]

--- a/src/commands/clean.rs
+++ b/src/commands/clean.rs
@@ -167,6 +167,23 @@ mod tests {
     }
 
     #[test]
+    fn should_clean_agents_project_targets() {
+        // Given
+        let temp = TempDir::new().unwrap();
+        let config = create_test_config(&temp);
+        let project_target = temp.path().join("project/.agents/skills");
+
+        create_managed_target(&project_target, "test-skill");
+
+        // When
+        clean(&config, false).unwrap();
+
+        // Then
+        assert!(!project_target.join("test-skill").exists());
+        assert!(!linker::is_managed(&project_target));
+    }
+
+    #[test]
     fn should_not_clean_in_dry_run_mode() {
         // Given
         let temp = TempDir::new().unwrap();

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -264,6 +264,22 @@ mod tests {
     }
 
     #[test]
+    fn should_install_project_skills_into_agents_directory() {
+        // Given
+        let temp = TempDir::new().unwrap();
+        create_test_skills(&temp);
+        let config = create_test_config(&temp);
+
+        // When
+        install(&config, false).unwrap();
+
+        // Then
+        let project_target = temp.path().join("project/.agents/skills");
+        assert!(project_target.join("test-skill").exists()); // inherited
+        assert!(project_target.join("another-skill").exists()); // project-specific
+    }
+
+    #[test]
     fn should_not_create_symlinks_in_dry_run_mode() {
         // Given
         let temp = TempDir::new().unwrap();

--- a/src/skill/frontmatter.rs
+++ b/src/skill/frontmatter.rs
@@ -73,7 +73,9 @@ pub struct PipelineStage {
 /// SKILL.md frontmatter
 ///
 /// This struct represents the union of all supported frontmatter fields
-/// across Claude Code and OpenCode. Only `name` and `description` are required.
+/// across Claude Code and OpenCode. Unknown fields are preserved by
+/// parser behavior and allowed for Codex/tool-specific metadata.
+/// Only `name` and `description` are required.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Frontmatter {
     /// Skill identifier (must match directory name)


### PR DESCRIPTION
## Summary
- document explicit Codex support via  and 
- clarify compatibility wording across README, DESIGN, AGENTS, and example config
- note permissive passthrough for tool-specific frontmatter keys in schema/docs
- add regression tests for project  behavior in install, clean, and check

## Validation
- cargo fmt
- cargo test