### PR TITLE
fix: reconcile stale managed links during loadout install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+- `loadout install` now reconciles managed targets by pruning stale managed symlinks before linking
+  currently enabled skills
+- Reconciliation applies across configured aliases for both global and project scopes, including
+  deselected alias targets
+
 ## [0.4.0] — 2026-03-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ annotated config.
 
 | Command | Purpose |
 |---------|---------|
-| `loadout install` | Link enabled skills into discovery paths |
+| `loadout install` | Reconcile managed links and link enabled skills into discovery paths |
 | `loadout install --dry-run` | Show what would happen without changes |
 | `loadout clean` | Remove all managed symlinks |
 | `loadout clean --dry-run` | Preview what would be cleaned |

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -1,15 +1,32 @@
 //! Install command implementation
 
-use std::collections::HashMap;
-use std::path::Path;
+use std::collections::{BTreeSet, HashMap, HashSet};
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use colored::Colorize;
 
 use crate::config::Config;
 use crate::linker;
-use crate::paths;
 use crate::skill;
+
+#[derive(Debug)]
+struct TargetPlan {
+    target: PathBuf,
+    skills: Vec<String>,
+}
+
+#[derive(Debug)]
+struct ProjectPlan {
+    project_path: PathBuf,
+    targets: Vec<TargetPlan>,
+}
+
+#[derive(Debug)]
+struct InstallPlan {
+    global_targets: Vec<TargetPlan>,
+    project_targets: Vec<ProjectPlan>,
+}
 
 /// Install skills by creating symlinks in target directories
 ///
@@ -24,17 +41,18 @@ pub fn install(config: &Config, dry_run: bool) -> Result<()> {
         .context("Failed to discover skills from source directories")?;
 
     let skill_map = skill::build_skill_map(skills);
+    let install_plan = build_install_plan(config)?;
 
     if dry_run {
         println!("{}", "[DRY RUN MODE]".yellow().bold());
         println!();
     }
 
-    // Link global skills
-    install_global_skills(config, &skill_map, dry_run)?;
+    // Reconcile + link global skills
+    install_global_skills(&install_plan, &skill_map, dry_run)?;
 
-    // Link project skills
-    install_project_skills(config, &skill_map, dry_run)?;
+    // Reconcile + link project skills
+    install_project_skills(&install_plan, &skill_map, dry_run)?;
 
     if !dry_run {
         println!();
@@ -44,53 +62,186 @@ pub fn install(config: &Config, dry_run: bool) -> Result<()> {
     Ok(())
 }
 
-/// Install global skills to global target directories
-fn install_global_skills(
+fn build_install_plan(config: &Config) -> Result<InstallPlan> {
+    let mut aliases: Vec<_> = config.target_aliases.keys().cloned().collect();
+    aliases.sort();
+    validate_global_aliases(config)?;
+
+    let selected_global: HashSet<_> = config.global.targets.iter().cloned().collect();
+    let mut global_targets = Vec::new();
+
+    for alias in &aliases {
+        let alias_paths = config
+            .target_aliases
+            .get(alias)
+            .context(format!("Unknown target alias '{alias}' in global.targets"))?;
+
+        let skills = if selected_global.contains(alias) {
+            unique_skills(config.global.skills.iter().cloned())
+        } else {
+            Vec::new()
+        };
+
+        global_targets.push(TargetPlan {
+            target: alias_paths.global.clone(),
+            skills,
+        });
+    }
+
+    let mut project_entries: Vec<_> = config.projects.iter().collect();
+    project_entries.sort_by(|(left, _), (right, _)| left.cmp(right));
+
+    let mut project_targets = Vec::new();
+    for (project_path, project_config) in project_entries {
+        validate_project_aliases(config, project_path, project_config)?;
+
+        let selected_aliases: HashSet<String> = project_config
+            .targets
+            .as_ref()
+            .unwrap_or(&config.global.targets)
+            .iter()
+            .cloned()
+            .collect();
+
+        let mut targets = Vec::new();
+        for alias in &aliases {
+            let alias_paths = config.target_aliases.get(alias).context(format!(
+                "Unknown target alias '{alias}' in projects.\"{}\".targets",
+                project_path.display()
+            ))?;
+
+            let target = if alias_paths.project.is_relative() {
+                project_path.join(&alias_paths.project)
+            } else {
+                alias_paths.project.clone()
+            };
+
+            let mut skills = Vec::new();
+            if selected_aliases.contains(alias) {
+                if project_config.inherit {
+                    skills.extend(config.global.skills.iter().cloned());
+                }
+                skills.extend(project_config.skills.iter().cloned());
+            }
+
+            targets.push(TargetPlan {
+                target,
+                skills: unique_skills(skills),
+            });
+        }
+
+        project_targets.push(ProjectPlan {
+            project_path: project_path.clone(),
+            targets,
+        });
+    }
+
+    Ok(InstallPlan {
+        global_targets,
+        project_targets,
+    })
+}
+
+fn validate_global_aliases(config: &Config) -> Result<()> {
+    for alias in &config.global.targets {
+        if !config.target_aliases.contains_key(alias) {
+            anyhow::bail!("Unknown target alias '{alias}' in global.targets");
+        }
+    }
+    Ok(())
+}
+
+fn validate_project_aliases(
     config: &Config,
+    project_path: &Path,
+    project_config: &crate::config::Project,
+) -> Result<()> {
+    let aliases = project_config
+        .targets
+        .as_ref()
+        .unwrap_or(&config.global.targets);
+    for alias in aliases {
+        if !config.target_aliases.contains_key(alias) {
+            anyhow::bail!(
+                "Unknown target alias '{alias}' in projects.\"{}\".targets",
+                project_path.display()
+            );
+        }
+    }
+    Ok(())
+}
+
+fn unique_skills(skills: impl IntoIterator<Item = String>) -> Vec<String> {
+    let mut deduped = BTreeSet::new();
+    for skill in skills {
+        deduped.insert(skill);
+    }
+    deduped.into_iter().collect()
+}
+
+/// Reconcile + install global skills to global target directories.
+fn install_global_skills(
+    plan: &InstallPlan,
     skill_map: &HashMap<String, skill::Skill>,
     dry_run: bool,
 ) -> Result<()> {
     println!("{}", "--- Global scope ---".cyan().bold());
 
-    for target in paths::global_targets(config)? {
-        println!("Target: {}", target.display());
+    for target_plan in &plan.global_targets {
+        println!("Target: {}", target_plan.target.display());
+        prune_stale_links(&target_plan.target, &target_plan.skills, dry_run)?;
 
-        for skill_name in &config.global.skills {
-            install_skill(skill_name, skill_map, &target, dry_run)?;
+        for skill_name in &target_plan.skills {
+            install_skill(skill_name, skill_map, &target_plan.target, dry_run)?;
         }
     }
 
     Ok(())
 }
 
-/// Install project-specific skills to project-local target directories
+/// Reconcile + install project-specific skills to project-local target directories.
 fn install_project_skills(
-    config: &Config,
+    plan: &InstallPlan,
     skill_map: &HashMap<String, skill::Skill>,
     dry_run: bool,
 ) -> Result<()> {
-    for (project_path, project_config) in &config.projects {
+    for project_plan in &plan.project_targets {
         println!();
         println!(
             "{} {}",
             "--- Project:".cyan().bold(),
-            project_path.display()
+            project_plan.project_path.display()
         );
 
-        for target in paths::project_targets(config, project_path, project_config)? {
-            println!("Target: {}", target.display());
+        for target_plan in &project_plan.targets {
+            println!("Target: {}", target_plan.target.display());
+            prune_stale_links(&target_plan.target, &target_plan.skills, dry_run)?;
 
-            // Link global skills if inherit is true
-            if project_config.inherit {
-                for skill_name in &config.global.skills {
-                    install_skill(skill_name, skill_map, &target, dry_run)?;
-                }
+            for skill_name in &target_plan.skills {
+                install_skill(skill_name, skill_map, &target_plan.target, dry_run)?;
             }
+        }
+    }
 
-            // Link project-specific skills
-            for skill_name in &project_config.skills {
-                install_skill(skill_name, skill_map, &target, dry_run)?;
-            }
+    Ok(())
+}
+
+fn prune_stale_links(target: &Path, desired_skills: &[String], dry_run: bool) -> Result<()> {
+    let removed = if dry_run {
+        linker::preview_prune_target(target, desired_skills)?
+    } else {
+        linker::prune_target_except(target, desired_skills)?
+    };
+
+    for stale_path in removed {
+        if dry_run {
+            println!(
+                "  {} would prune: {}",
+                "[dry-run]".yellow(),
+                stale_path.display()
+            );
+        } else {
+            println!("  {} {}", "pruned:".green(), stale_path.display());
         }
     }
 
@@ -137,7 +288,9 @@ fn install_skill(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{default_target_aliases, Global, Project, Sources};
+    use crate::config::{Global, Project, Sources, TargetAliasPaths};
+    use crate::paths;
+    use std::collections::HashMap;
     use std::fs;
     use tempfile::TempDir;
 
@@ -146,12 +299,33 @@ mod tests {
         let global_target = temp.path().join("global");
         let project_path = temp.path().join("project");
 
-        let mut target_aliases = default_target_aliases();
+        let mut target_aliases = HashMap::new();
         target_aliases.insert(
             "test_runner".to_string(),
-            crate::config::TargetAliasPaths {
+            TargetAliasPaths {
                 global: global_target,
                 project: std::path::PathBuf::from(".test-runner/skills"),
+            },
+        );
+        target_aliases.insert(
+            "codex".to_string(),
+            TargetAliasPaths {
+                global: temp.path().join("codex-global"),
+                project: std::path::PathBuf::from(".agents/skills"),
+            },
+        );
+        target_aliases.insert(
+            "claude_code".to_string(),
+            TargetAliasPaths {
+                global: temp.path().join("claude-global"),
+                project: std::path::PathBuf::from(".claude/skills"),
+            },
+        );
+        target_aliases.insert(
+            "opencode".to_string(),
+            TargetAliasPaths {
+                global: temp.path().join("opencode-global"),
+                project: std::path::PathBuf::from(".opencode/skills"),
             },
         );
 
@@ -400,5 +574,104 @@ inherit = false
             assert!(link_path.is_symlink());
             assert_eq!(fs::canonicalize(link_path).unwrap(), expected);
         }
+    }
+
+    #[test]
+    fn should_prune_removed_global_skill_when_reinstalling() {
+        // Given
+        let temp = TempDir::new().unwrap();
+        create_test_skills(&temp);
+        let mut config = create_test_config(&temp);
+        install(&config, false).unwrap();
+        let global_target = temp.path().join("global");
+        assert!(global_target.join("test-skill").exists());
+
+        config.global.skills.clear();
+
+        // When
+        install(&config, false).unwrap();
+
+        // Then
+        assert!(!global_target.join("test-skill").exists());
+    }
+
+    #[test]
+    fn should_prune_removed_project_skill_when_reinstalling() {
+        // Given
+        let temp = TempDir::new().unwrap();
+        create_test_skills(&temp);
+        let mut config = create_test_config(&temp);
+        install(&config, false).unwrap();
+        let project_target = temp.path().join("project/.test-runner/skills");
+        assert!(project_target.join("another-skill").exists());
+
+        let project_path = temp.path().join("project");
+        config
+            .projects
+            .get_mut(&project_path)
+            .unwrap()
+            .skills
+            .clear();
+        config.projects.get_mut(&project_path).unwrap().inherit = false;
+
+        // When
+        install(&config, false).unwrap();
+
+        // Then
+        assert!(!project_target.join("another-skill").exists());
+    }
+
+    #[test]
+    fn should_prune_links_in_deselected_alias_targets() {
+        // Given
+        let temp = TempDir::new().unwrap();
+        create_test_skills(&temp);
+        let mut config = create_test_config(&temp);
+        config.global.targets = vec!["claude_code".to_string(), "codex".to_string()];
+        let project_path = temp.path().join("project");
+        config.projects.get_mut(&project_path).unwrap().targets =
+            Some(vec!["claude_code".to_string(), "codex".to_string()]);
+        install(&config, false).unwrap();
+        assert!(temp.path().join("claude-global/test-skill").exists());
+        assert!(temp
+            .path()
+            .join("project/.claude/skills/test-skill")
+            .exists());
+
+        config.global.targets = vec!["codex".to_string()];
+        config.projects.get_mut(&project_path).unwrap().targets = Some(vec!["codex".to_string()]);
+
+        // When
+        install(&config, false).unwrap();
+
+        // Then
+        assert!(!temp.path().join("claude-global/test-skill").exists());
+        assert!(!temp
+            .path()
+            .join("project/.claude/skills/test-skill")
+            .exists());
+        assert!(temp.path().join("codex-global/test-skill").exists());
+        assert!(temp
+            .path()
+            .join("project/.agents/skills/test-skill")
+            .exists());
+    }
+
+    #[test]
+    fn should_not_prune_in_dry_run_mode() {
+        // Given
+        let temp = TempDir::new().unwrap();
+        create_test_skills(&temp);
+        let mut config = create_test_config(&temp);
+        install(&config, false).unwrap();
+        let global_target = temp.path().join("global");
+        assert!(global_target.join("test-skill").exists());
+        config.global.skills.clear();
+
+        // When
+        install(&config, true).unwrap();
+
+        // Then
+        assert!(global_target.join("test-skill").exists());
     }
 }

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -181,17 +181,43 @@ fn install_targets(
     skill_map: &HashMap<String, skill::Skill>,
     dry_run: bool,
 ) -> Result<()> {
-    println!("{}", "--- Reconcile targets ---".cyan().bold());
-    for target_plan in &plan.targets {
-        println!("Target: {}", target_plan.target.display());
-        prune_stale_links(&target_plan.target, &target_plan.skills, dry_run)?;
+    let resolved = resolve_planned_skills(plan, skill_map)?;
 
-        for skill_name in &target_plan.skills {
-            install_skill(skill_name, skill_map, &target_plan.target, dry_run)?;
+    println!("{}", "--- Reconcile targets ---".cyan().bold());
+    for (target, skills) in resolved {
+        let desired_skill_names: Vec<String> =
+            skills.iter().map(|(name, _)| name.clone()).collect();
+
+        println!("Target: {}", target.display());
+        prune_stale_links(&target, &desired_skill_names, dry_run)?;
+
+        for (skill_name, skill_path) in skills {
+            install_resolved_skill(&skill_name, &skill_path, &target, dry_run)?;
         }
     }
 
     Ok(())
+}
+
+fn resolve_planned_skills(
+    plan: &InstallPlan,
+    skill_map: &HashMap<String, skill::Skill>,
+) -> Result<Vec<(PathBuf, Vec<(String, PathBuf)>)>> {
+    let mut resolved = Vec::new();
+
+    for target_plan in &plan.targets {
+        let mut target_skills = Vec::new();
+        for skill_name in &target_plan.skills {
+            let skill = skill_map.get(skill_name).context(format!(
+                "Skill '{}' not found in source directories",
+                skill_name
+            ))?;
+            target_skills.push((skill_name.clone(), skill.path.clone()));
+        }
+        resolved.push((target_plan.target.clone(), target_skills));
+    }
+
+    Ok(resolved)
 }
 
 fn prune_stale_links(target: &Path, desired_skills: &[String], dry_run: bool) -> Result<()> {
@@ -217,26 +243,21 @@ fn prune_stale_links(target: &Path, desired_skills: &[String], dry_run: bool) ->
 }
 
 /// Install a single skill to a target directory
-fn install_skill(
+fn install_resolved_skill(
     skill_name: &str,
-    skill_map: &HashMap<String, skill::Skill>,
+    skill_path: &Path,
     target: &Path,
     dry_run: bool,
 ) -> Result<()> {
-    let skill = skill_map.get(skill_name).context(format!(
-        "Skill '{}' not found in source directories",
-        skill_name
-    ))?;
-
     if dry_run {
         println!(
             "  {} {} -> {}",
             "[dry-run]".yellow(),
-            skill.path.display(),
+            skill_path.display(),
             target.join(skill_name).display()
         );
     } else {
-        linker::link_skill(skill_name, &skill.path, target).context(format!(
+        linker::link_skill(skill_name, skill_path, target).context(format!(
             "Failed to link skill '{}' to {}",
             skill_name,
             target.display()
@@ -494,6 +515,50 @@ mod tests {
         let err = result.unwrap_err();
         assert!(err.to_string().contains("not found"));
         assert!(err.to_string().contains("nonexistent"));
+    }
+
+    #[test]
+    fn should_not_prune_existing_links_when_global_skill_not_found() {
+        // Given
+        let temp = TempDir::new().unwrap();
+        create_test_skills(&temp);
+        let mut config = create_test_config(&temp);
+        install(&config, false).unwrap();
+        let global_target = temp.path().join("global");
+        assert!(global_target.join("test-skill").exists());
+        config.global.skills.push("nonexistent".to_string());
+
+        // When
+        let result = install(&config, false);
+
+        // Then
+        assert!(result.is_err());
+        assert!(global_target.join("test-skill").exists());
+    }
+
+    #[test]
+    fn should_not_prune_existing_links_when_project_skill_not_found() {
+        // Given
+        let temp = TempDir::new().unwrap();
+        create_test_skills(&temp);
+        let mut config = create_test_config(&temp);
+        install(&config, false).unwrap();
+        let project_target = temp.path().join("project/.test-runner/skills");
+        assert!(project_target.join("another-skill").exists());
+        let project_path = temp.path().join("project");
+        config
+            .projects
+            .get_mut(&project_path)
+            .unwrap()
+            .skills
+            .push("nonexistent".to_string());
+
+        // When
+        let result = install(&config, false);
+
+        // Then
+        assert!(result.is_err());
+        assert!(project_target.join("another-skill").exists());
     }
 
     #[test]

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -1,6 +1,6 @@
 //! Install command implementation
 
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
@@ -17,15 +17,8 @@ struct TargetPlan {
 }
 
 #[derive(Debug)]
-struct ProjectPlan {
-    project_path: PathBuf,
-    targets: Vec<TargetPlan>,
-}
-
-#[derive(Debug)]
 struct InstallPlan {
-    global_targets: Vec<TargetPlan>,
-    project_targets: Vec<ProjectPlan>,
+    targets: Vec<TargetPlan>,
 }
 
 /// Install skills by creating symlinks in target directories
@@ -48,11 +41,8 @@ pub fn install(config: &Config, dry_run: bool) -> Result<()> {
         println!();
     }
 
-    // Reconcile + link global skills
-    install_global_skills(&install_plan, &skill_map, dry_run)?;
-
-    // Reconcile + link project skills
-    install_project_skills(&install_plan, &skill_map, dry_run)?;
+    // Reconcile + link targets
+    install_targets(&install_plan, &skill_map, dry_run)?;
 
     if !dry_run {
         println!();
@@ -68,7 +58,7 @@ fn build_install_plan(config: &Config) -> Result<InstallPlan> {
     validate_global_aliases(config)?;
 
     let selected_global: HashSet<_> = config.global.targets.iter().cloned().collect();
-    let mut global_targets = Vec::new();
+    let mut consolidated: BTreeMap<PathBuf, BTreeSet<String>> = BTreeMap::new();
 
     for alias in &aliases {
         let alias_paths = config
@@ -76,22 +66,25 @@ fn build_install_plan(config: &Config) -> Result<InstallPlan> {
             .get(alias)
             .context(format!("Unknown target alias '{alias}' in global.targets"))?;
 
-        let skills = if selected_global.contains(alias) {
+        if selected_global.contains(alias) {
             unique_skills(config.global.skills.iter().cloned())
         } else {
             Vec::new()
-        };
-
-        global_targets.push(TargetPlan {
-            target: alias_paths.global.clone(),
-            skills,
+        }
+        .into_iter()
+        .for_each(|skill_name| {
+            consolidated
+                .entry(alias_paths.global.clone())
+                .or_default()
+                .insert(skill_name);
         });
+
+        consolidated.entry(alias_paths.global.clone()).or_default();
     }
 
     let mut project_entries: Vec<_> = config.projects.iter().collect();
     project_entries.sort_by(|(left, _), (right, _)| left.cmp(right));
 
-    let mut project_targets = Vec::new();
     for (project_path, project_config) in project_entries {
         validate_project_aliases(config, project_path, project_config)?;
 
@@ -103,7 +96,6 @@ fn build_install_plan(config: &Config) -> Result<InstallPlan> {
             .cloned()
             .collect();
 
-        let mut targets = Vec::new();
         for alias in &aliases {
             let alias_paths = config.target_aliases.get(alias).context(format!(
                 "Unknown target alias '{alias}' in projects.\"{}\".targets",
@@ -116,6 +108,8 @@ fn build_install_plan(config: &Config) -> Result<InstallPlan> {
                 alias_paths.project.clone()
             };
 
+            consolidated.entry(target.clone()).or_default();
+
             let mut skills = Vec::new();
             if selected_aliases.contains(alias) {
                 if project_config.inherit {
@@ -124,22 +118,24 @@ fn build_install_plan(config: &Config) -> Result<InstallPlan> {
                 skills.extend(project_config.skills.iter().cloned());
             }
 
-            targets.push(TargetPlan {
-                target,
-                skills: unique_skills(skills),
-            });
+            for skill_name in unique_skills(skills) {
+                consolidated
+                    .entry(target.clone())
+                    .or_default()
+                    .insert(skill_name);
+            }
         }
-
-        project_targets.push(ProjectPlan {
-            project_path: project_path.clone(),
-            targets,
-        });
     }
 
-    Ok(InstallPlan {
-        global_targets,
-        project_targets,
-    })
+    let targets = consolidated
+        .into_iter()
+        .map(|(target, skills)| TargetPlan {
+            target,
+            skills: skills.into_iter().collect(),
+        })
+        .collect();
+
+    Ok(InstallPlan { targets })
 }
 
 fn validate_global_aliases(config: &Config) -> Result<()> {
@@ -179,47 +175,19 @@ fn unique_skills(skills: impl IntoIterator<Item = String>) -> Vec<String> {
     deduped.into_iter().collect()
 }
 
-/// Reconcile + install global skills to global target directories.
-fn install_global_skills(
+/// Reconcile + install skills to all unique target directories.
+fn install_targets(
     plan: &InstallPlan,
     skill_map: &HashMap<String, skill::Skill>,
     dry_run: bool,
 ) -> Result<()> {
-    println!("{}", "--- Global scope ---".cyan().bold());
-
-    for target_plan in &plan.global_targets {
+    println!("{}", "--- Reconcile targets ---".cyan().bold());
+    for target_plan in &plan.targets {
         println!("Target: {}", target_plan.target.display());
         prune_stale_links(&target_plan.target, &target_plan.skills, dry_run)?;
 
         for skill_name in &target_plan.skills {
             install_skill(skill_name, skill_map, &target_plan.target, dry_run)?;
-        }
-    }
-
-    Ok(())
-}
-
-/// Reconcile + install project-specific skills to project-local target directories.
-fn install_project_skills(
-    plan: &InstallPlan,
-    skill_map: &HashMap<String, skill::Skill>,
-    dry_run: bool,
-) -> Result<()> {
-    for project_plan in &plan.project_targets {
-        println!();
-        println!(
-            "{} {}",
-            "--- Project:".cyan().bold(),
-            project_plan.project_path.display()
-        );
-
-        for target_plan in &project_plan.targets {
-            println!("Target: {}", target_plan.target.display());
-            prune_stale_links(&target_plan.target, &target_plan.skills, dry_run)?;
-
-            for skill_name in &target_plan.skills {
-                install_skill(skill_name, skill_map, &target_plan.target, dry_run)?;
-            }
         }
     }
 
@@ -673,5 +641,78 @@ inherit = false
 
         // Then
         assert!(global_target.join("test-skill").exists());
+    }
+
+    #[test]
+    fn should_not_prune_selected_skills_when_aliases_share_global_target_path() {
+        // Given
+        let temp = TempDir::new().unwrap();
+        create_test_skills(&temp);
+        let mut config = create_test_config(&temp);
+        let shared_global = temp.path().join("shared-global");
+        config.target_aliases.insert(
+            "zzz_runner".to_string(),
+            TargetAliasPaths {
+                global: shared_global.clone(),
+                project: std::path::PathBuf::from(".zzz/skills"),
+            },
+        );
+        config.target_aliases.insert(
+            "aaa_runner".to_string(),
+            TargetAliasPaths {
+                global: shared_global.clone(),
+                project: std::path::PathBuf::from(".aaa/skills"),
+            },
+        );
+        config.global.targets = vec!["aaa_runner".to_string()];
+        config.projects.clear();
+
+        // When
+        install(&config, false).unwrap();
+
+        // Then
+        assert!(shared_global.join("test-skill").exists());
+    }
+
+    #[test]
+    fn should_union_skills_when_projects_share_absolute_project_target_path() {
+        // Given
+        let temp = TempDir::new().unwrap();
+        create_test_skills(&temp);
+        let mut config = create_test_config(&temp);
+        let shared_project_target = temp.path().join("shared-project-target");
+        config.target_aliases.insert(
+            "shared".to_string(),
+            TargetAliasPaths {
+                global: temp.path().join("shared-global"),
+                project: shared_project_target.clone(),
+            },
+        );
+        config.global.targets = vec![];
+        config.global.skills.clear();
+        config.projects.clear();
+        config.projects.insert(
+            temp.path().join("project-a"),
+            Project {
+                skills: vec!["test-skill".to_string()],
+                inherit: false,
+                targets: Some(vec!["shared".to_string()]),
+            },
+        );
+        config.projects.insert(
+            temp.path().join("project-b"),
+            Project {
+                skills: vec!["another-skill".to_string()],
+                inherit: false,
+                targets: Some(vec!["shared".to_string()]),
+            },
+        );
+
+        // When
+        install(&config, false).unwrap();
+
+        // Then
+        assert!(shared_project_target.join("test-skill").exists());
+        assert!(shared_project_target.join("another-skill").exists());
     }
 }

--- a/src/linker/mod.rs
+++ b/src/linker/mod.rs
@@ -122,6 +122,19 @@ pub fn clean_target(target_dir: &Path) -> Result<Vec<PathBuf>> {
     Ok(removed)
 }
 
+/// List managed symlinks in a target directory that would be pruned.
+pub fn preview_prune_target(
+    target_dir: &Path,
+    keep_skill_names: &[String],
+) -> Result<Vec<PathBuf>> {
+    prune_target_impl(target_dir, keep_skill_names, true)
+}
+
+/// Remove managed symlinks from a target directory except the provided skill names.
+pub fn prune_target_except(target_dir: &Path, keep_skill_names: &[String]) -> Result<Vec<PathBuf>> {
+    prune_target_impl(target_dir, keep_skill_names, false)
+}
+
 /// Create a marker file in the target directory
 fn create_marker(target_dir: &Path) -> Result<()> {
     let marker_path = target_dir.join(MARKER_FILE_NAME);
@@ -159,6 +172,58 @@ pub fn is_managed(target_dir: &Path) -> bool {
 fn remove_symlink(path: &Path) -> Result<()> {
     fs::remove_file(path).context(format!("Failed to remove symlink: {}", path.display()))?;
     Ok(())
+}
+
+fn prune_target_impl(
+    target_dir: &Path,
+    keep_skill_names: &[String],
+    dry_run: bool,
+) -> Result<Vec<PathBuf>> {
+    if !is_managed(target_dir) {
+        return Ok(Vec::new());
+    }
+
+    let mut removed = Vec::new();
+
+    if target_dir.exists() && target_dir.is_dir() {
+        for entry in fs::read_dir(target_dir).context(format!(
+            "Failed to read directory: {}",
+            target_dir.display()
+        ))? {
+            let entry = entry?;
+            let path = entry.path();
+
+            if path.file_name().and_then(|n| n.to_str()) == Some(MARKER_FILE_NAME) {
+                continue;
+            }
+
+            if !path.is_symlink() {
+                continue;
+            }
+
+            let skill_name = path.file_name().and_then(|n| n.to_str());
+            if skill_name.is_some_and(|name| keep_skill_names.iter().any(|keep| keep == name)) {
+                continue;
+            }
+
+            if !dry_run {
+                remove_symlink(&path)?;
+            }
+            removed.push(path);
+        }
+    }
+
+    if !dry_run && has_only_marker_or_is_empty(target_dir)? {
+        remove_marker(target_dir)?;
+        if is_directory_empty(target_dir)? {
+            fs::remove_dir(target_dir).context(format!(
+                "Failed to remove empty directory: {}",
+                target_dir.display()
+            ))?;
+        }
+    }
+
+    Ok(removed)
 }
 
 fn resolve_symlink_destination(link_path: &Path, current_target: &Path) -> Result<PathBuf> {
@@ -236,6 +301,21 @@ fn create_symlink(source: &Path, link_path: &Path) -> Result<()> {
 fn is_directory_empty(dir: &Path) -> Result<bool> {
     let entries: Vec<_> = fs::read_dir(dir)?.collect();
     Ok(entries.is_empty())
+}
+
+fn has_only_marker_or_is_empty(dir: &Path) -> Result<bool> {
+    if !dir.exists() || !dir.is_dir() {
+        return Ok(false);
+    }
+
+    for entry in fs::read_dir(dir)? {
+        let entry = entry?;
+        if entry.file_name().to_str() != Some(MARKER_FILE_NAME) {
+            return Ok(false);
+        }
+    }
+
+    Ok(true)
 }
 
 #[cfg(test)]
@@ -438,6 +518,64 @@ mod tests {
 
         // When - after marker
         create_marker(&target_dir).unwrap();
+        assert!(is_managed(&target_dir));
+    }
+
+    #[test]
+    fn should_prune_stale_symlinks_and_keep_requested_skills() {
+        // Given
+        let temp = TempDir::new().unwrap();
+        let source_a = temp.path().join("source-a");
+        let source_b = temp.path().join("source-b");
+        let target_dir = temp.path().join("target");
+        fs::create_dir_all(&source_a).unwrap();
+        fs::create_dir_all(&source_b).unwrap();
+        link_skill("keep-skill", &source_a, &target_dir).unwrap();
+        link_skill("stale-skill", &source_b, &target_dir).unwrap();
+        let keep = vec!["keep-skill".to_string()];
+
+        // When
+        let removed = prune_target_except(&target_dir, &keep).unwrap();
+
+        // Then
+        assert_eq!(removed.len(), 1);
+        assert!(target_dir.join("keep-skill").exists());
+        assert!(!target_dir.join("stale-skill").exists());
+    }
+
+    #[test]
+    fn should_remove_marker_and_directory_when_prune_empties_target() {
+        // Given
+        let temp = TempDir::new().unwrap();
+        let source = temp.path().join("source");
+        let target_dir = temp.path().join("target");
+        fs::create_dir_all(&source).unwrap();
+        link_skill("stale-skill", &source, &target_dir).unwrap();
+        let keep = Vec::new();
+
+        // When
+        prune_target_except(&target_dir, &keep).unwrap();
+
+        // Then
+        assert!(!target_dir.exists());
+    }
+
+    #[test]
+    fn should_preview_prune_without_removing_symlinks() {
+        // Given
+        let temp = TempDir::new().unwrap();
+        let source = temp.path().join("source");
+        let target_dir = temp.path().join("target");
+        fs::create_dir_all(&source).unwrap();
+        link_skill("stale-skill", &source, &target_dir).unwrap();
+        let keep = Vec::new();
+
+        // When
+        let removed = preview_prune_target(&target_dir, &keep).unwrap();
+
+        // Then
+        assert_eq!(removed.len(), 1);
+        assert!(target_dir.join("stale-skill").exists());
         assert!(is_managed(&target_dir));
     }
 }


### PR DESCRIPTION
## Summary
- make loadout install reconciliatory by default (prune stale managed symlinks before linking)
- apply prune behavior across configured aliases in global and project scopes, including deselected alias targets
- keep --dry-run non-mutating while reporting prune actions
- document the updated install behavior in README and CHANGELOG

## Testing
- cargo test -- --nocapture

Closes #43